### PR TITLE
:bug: fix qq adapter rich media file types

### DIFF
--- a/src/satori/adapters/qq/message.py
+++ b/src/satori/adapters/qq/message.py
@@ -358,9 +358,9 @@ class QQGroupMessageEncoder(QQBotMessageEncoder):
         match type_:
             case "img" | "image":
                 file_type = 1
-            case "audio":
-                file_type = 2
             case "video":
+                file_type = 2
+            case "audio":
                 file_type = 3
             case _:
                 file_type = 4


### PR DESCRIPTION
According to [QQ 机器人官方文档](https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/send-receive/rich-media.html), `file_type` for videos and voices are 2 and 3 respectively. The current implementation mixed up the two.